### PR TITLE
Fix --local-sdk flag

### DIFF
--- a/cdn/sdk.json
+++ b/cdn/sdk.json
@@ -1,6 +1,6 @@
 {
 	"toolCompatibility": "^.*$",
-	"toolVersion": "2.3.1",
+	"toolVersion": "2.3.3",
 	"toolDownloadUrl": "https://raw.githubusercontent.com/ByteWelder/TactilityTool/refs/heads/main/tactility.py",
 	"versions": {
 		"0.4.0" : { "platforms": [ "esp32", "esp32s3"] },

--- a/tactility.py
+++ b/tactility.py
@@ -132,21 +132,22 @@ def get_sdk_dir(version, platform):
         base_path = local_base_path
         if base_path is None:
             exit_with_error("TACTILITY_SDK_PATH environment variable is not set")
-        sdk_dir = os.path.join(base_path, platform, "TactilitySDK")
+        sdk_parent_dir = os.path.join(base_path, f"{version}-{platform}")
+        sdk_dir = os.path.join(sdk_parent_dir, "TactilitySDK")
         if not os.path.isdir(sdk_dir):
             exit_with_error(f"Local SDK folder not found for platform {platform}: {sdk_dir}")
         return sdk_dir
     else:
-        global ttbuild_cdn
         return os.path.join(ttbuild_path, f"{version}-{platform}", "TactilitySDK")
 
-def validate_local_sdks(platforms):
+def validate_local_sdks(platforms, version):
     if not use_local_sdk:
         return
     global local_base_path
     base_path = local_base_path
     for platform in platforms:
-        sdk_dir = os.path.join(base_path, platform, "TactilitySDK")
+        sdk_parent_dir = os.path.join(base_path, f"{version}-{platform}")
+        sdk_dir = os.path.join(sdk_parent_dir, "TactilitySDK")
         if not os.path.isdir(sdk_dir):
             exit_with_error(f"Local SDK folder missing for {platform}: {sdk_dir}")
 
@@ -476,7 +477,7 @@ def build_action(manifest, platform_arg):
     if use_local_sdk:
         global local_base_path
         local_base_path = os.environ.get("TACTILITY_SDK_PATH")
-        validate_local_sdks(platforms_to_build)
+        validate_local_sdks(platforms_to_build, manifest["target"]["sdk"])
     
     if should_fetch_sdkconfig_files(platforms_to_build):
         fetch_sdkconfig_files(platforms_to_build)

--- a/tactility.py
+++ b/tactility.py
@@ -131,7 +131,7 @@ def get_sdk_dir(version, platform):
         base_path = os.environ.get("TACTILITY_SDK_PATH")
         if base_path is None:
             exit_with_error("TACTILITY_SDK_PATH environment variable is not set")
-        sdk_dir = os.path.join(base_path, platform)
+        sdk_dir = os.path.join(base_path, platform, "TactilitySDK")
         if not os.path.isdir(sdk_dir):
             exit_with_error(f"Local SDK folder not found for platform {platform}: {sdk_dir}")
         return sdk_dir


### PR DESCRIPTION
This resolves the issue I asked you about on Discord, where the --local-sdk flag only supports a single path.

I improved the validation and fetching for the local SDK, and fixed a potential bug (this may be intentional), that passing the --local-sdk flag on a fresh build doesn't download the sdkconfig.app.* files. Let me know if something should be changed/fixed.

I don't know whether contributions for this repo are open, so this is a draft PR for now!